### PR TITLE
Fix oshpark drill file extension.  Needs to be .XLN not .TXT

### DIFF
--- a/cam/oshpark-gerb274x.cam
+++ b/cam/oshpark-gerb274x.cam
@@ -1,5 +1,5 @@
 [CAM Processor Job]
-Description[en]="\n\n\n\n\n\n\n\n\n\n\n\n<b>SparkFun Gerber Generator</b><p>\n\nThis CAM job creates the seven needed files to have a PCB created. Based on the original Eagle gerb274x.cam file.<p><p>\nYou will get seven gerber files that contain data for:<br>\n<b>g</b>erber <b>t</b>op <b>l</b>ayer (copper layer): *.GTL<br>\n<b>g</b>erber <b>t</b>op <b>o</b>verlay (silkscreen layer): *.GTO<br>\n<b>g</b>erber <b>t</b>op <b>s</b>oldermask (soldermask layer): *.GTS<br>\n\n<b>g</b>erber <b>b</b>ottom <b>l</b>ayer (copper layer): *.GBL<br>\n<b>g</b>erber <b>b</b>ottom <b>o</b>verlay (silkscreen layer): *.GBO<br>\n<b>g</b>erber <b>b</b>ottom <b>s</b>oldermask (soldermask layer): *.GBS<br>\n\nExcellon Drill File: *.TXT<br><br>\nThese files, zipped together, are the only 7 files you need to have a PCB made at nearly any fab house.\n"
+Description[en]="\n\n\n\n\n\n\n\n\n\n\n\n<b>SparkFun Gerber Generator</b><p>\n\nThis CAM job creates the seven needed files to have a PCB created. Based on the original Eagle gerb274x.cam file.<p><p>\nYou will get seven gerber files that contain data for:<br>\n<b>g</b>erber <b>t</b>op <b>l</b>ayer (copper layer): *.GTL<br>\n<b>g</b>erber <b>t</b>op <b>o</b>verlay (silkscreen layer): *.GTO<br>\n<b>g</b>erber <b>t</b>op <b>s</b>oldermask (soldermask layer): *.GTS<br>\n\n<b>g</b>erber <b>b</b>ottom <b>l</b>ayer (copper layer): *.GBL<br>\n<b>g</b>erber <b>b</b>ottom <b>o</b>verlay (silkscreen layer): *.GBO<br>\n<b>g</b>erber <b>b</b>ottom <b>s</b>oldermask (soldermask layer): *.GBS<br>\n\nExcellon Drill File: *.XLN<br><br>\nThese files, zipped together, are the only 7 files you need to have a PCB made at nearly any fab house.\n"
 Section=Sec_1
 Section=Sec_2
 Section=Sec_3
@@ -162,7 +162,7 @@ Device="EXCELLON"
 Wheel=""
 Rack=""
 Scale=1
-Output=".TXT"
+Output=".XLN"
 Flags="0 0 0 1 0 1 1"
 Emulate="0"
 Offset="0.0mil 0.0mil"


### PR DESCRIPTION
OSH Park guidelines call for a .XLN extension in their gerbers.

https://oshpark.com/guidelines
    boardname.GTL Top Layer
    boardname.GBL Bottom Layer
    boardname.GTS Top Soldermask
    boardname.GBS Bottom Soldermask
    boardname.GTO Top Silkscreen
    boardname.GBO Bottom Silkscreen
    boardname.GKO Board Outline
    boardname.G2L only if you're uploading a four layer board
    boardname.G3L only if you're uploading a four layer board
    boardname.XLN Drills

Fix only tested by visualization on the website.
No boards sent to the fab yet
