### PR TITLE
checking for 4-layer or 6-layers (with no wires)

### DIFF
--- a/ulp/SparkFun-CAMmer.ulp
+++ b/ulp/SparkFun-CAMmer.ulp
@@ -108,6 +108,17 @@ int hasFourLayers()
 					return (1);
 				}
 			}
+			S.polygons(P)
+			{
+				if (P.layer == 2)
+				{
+					return (1);
+				}
+				if (P.layer == 15)
+				{
+					return (1);
+				}
+			}			
 		}
 	}
 	return (0); //Nope
@@ -131,6 +142,17 @@ int hasSixLayers()
 					return (1);
 				}
 			}
+			S.polygons(P)
+			{
+				if (P.layer == 3)
+				{
+					return (1);
+				}
+				if (P.layer == 14)
+				{
+					return (1);
+				}
+			}					
 		}
 	}
 	return (0); //Nope


### PR DESCRIPTION
Previously, the check for 4-layer or 6-layer boards only looked for wires on those inner layers. This means if you only have polygons, then it would miss the inner layers.

Now it checks for wires and polygons, so it will do a better job of catching >2 layer boards.