### PR TITLE
Catch 4 and 6 layers polygons with no wires.

### DIFF
--- a/ulp/SparkFun-Panelizer.ulp
+++ b/ulp/SparkFun-Panelizer.ulp
@@ -183,6 +183,17 @@ int hasFourLayers()
 					return (1);
 				}
 			}
+			S.polygons(P)
+			{
+				if (P.layer == 2)
+				{
+					return (1);
+				}
+				if (P.layer == 15)
+				{
+					return (1);
+				}
+			}			
 		}
 	}
 	return (0); //Nope
@@ -206,6 +217,17 @@ int hasSixLayers()
 					return (1);
 				}
 			}
+			S.polygons(P)
+			{
+				if (P.layer == 3)
+				{
+					return (1);
+				}
+				if (P.layer == 14)
+				{
+					return (1);
+				}
+			}			
 		}
 	}
 	return (0); //Nope


### PR DESCRIPTION
CAMmer is working, but panelizer needed the update as well to correctly generate ordering instructions.